### PR TITLE
New feature: fetch rate from an older date

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This library exposes 3 main classes to interact with, `Rates`, `Countries` and `
 $rates = new DvK\Vat\Rates\Rates();
 $rates->country('NL'); // 21
 $rates->country('NL', 'standard'); // 21
+$rates->country('NL', 'standard', new \Datetime('2010-01-01')); // 19
 $rates->country('NL', 'reduced'); // 6
 $rates->all(); // array in country code => rates format
 ```

--- a/src/Rates/Caches/NullCache.php
+++ b/src/Rates/Caches/NullCache.php
@@ -20,7 +20,7 @@ class NullCache implements CacheInterface
     /**
      * @param string $key
      * @param mixed $value
-     * @param null|int|DateInterval $ttl
+     * @param null|int|\DateInterval $ttl
      *
      * @return bool
      */
@@ -58,7 +58,7 @@ class NullCache implements CacheInterface
 
     /**
      * @param iterable $values
-     * @param null|int|DateInterval $ttl
+     * @param null|int|\DateInterval $ttl
      *
      * @return bool
      */

--- a/src/Rates/Clients/JsonVat.php
+++ b/src/Rates/Clients/JsonVat.php
@@ -30,14 +30,9 @@ class JsonVat implements Client{
         if( empty( $response_body ) ) {
             throw new ClientException( "Error fetching rates from {$url}.");
         }
-        $data = json_decode($response_body);
 
-        // build map with country codes => rates
-        $map = array();
-        foreach ($data->rates as $rate) {
-            $map[$rate->country_code] = $rate->periods[0]->rates;
-        }
-
-        return $map;
+        $data = json_decode($response_body, true);
+        $output = array_combine(array_column($data['rates'], 'country_code'), $data['rates']);
+        return $output;
     }
 }

--- a/src/Rates/Interfaces/Client.php
+++ b/src/Rates/Interfaces/Client.php
@@ -15,12 +15,29 @@ interface Client {
      * This methods should return an associative array in the following format:
      *
      * [
-     *    'DE' => [
-     *      'standard' => 19,
-     *      'reduced' => 7.0,
-     *    ],
-     *    ...
+     *    'NL' => [
+     *        'name'         => 'Netherlands',
+     *        'code'         => 'NL',
+     *        'country_code' => 'NL',
+     *        'periods'      => [
+     *            [
+     *            'effective_from' => '2012-10-01',
+     *            'rates'          => [
+     *                'reduced'  => 6.0,
+     *                'standard' => 21.0,
+     *                ],
+     *            ],
+     *            [
+     *            'effective_from' => '0000-01-01',
+     *            'rates'          => [
+     *                'reduced'  => 5.0,
+     *                'standard' => 19.0,
+     *                ],
+     *            ],
+     *        ],
+     *    ]
      * ]
+     *
      *
      * @throws ClientException
      *

--- a/src/Rates/Rates.php
+++ b/src/Rates/Rates.php
@@ -17,7 +17,7 @@ class Rates
     protected $map = array();
 
     /**
-     * @var Cache
+     * @var CacheInterface
      */
     protected $cache;
 
@@ -30,7 +30,7 @@ class Rates
      * Rates constructor.
      *
      * @param Client $client     (optional)
-     * @param Cache $cache          (optional)
+     * @param CacheInterface $cache          (optional)
      */
     public function __construct( Client $client = null, CacheInterface $cache = null )
     {

--- a/src/Rates/Rates.php
+++ b/src/Rates/Rates.php
@@ -80,25 +80,50 @@ class Rates
     /**
      * @param string $country
      * @param string $rate
+     * @param \DateTimeInterface $applicableDate - optionnal - the applicable date
      *
      * @return double
      *
      * @throws Exception
      */
-    public function country($country, $rate = 'standard')
+    public function country($country, $rate = 'standard', \DateTimeInterface $applicableDate = null)
     {
         $country = strtoupper($country);
         $country = $this->getCountryCode($country);
+
+        if (null === $applicableDate) {
+            $applicableDate = new \DateTime('today midnight');
+        }
 
         if (!isset($this->map[$country])) {
             throw new Exception('Invalid country code.');
         }
 
-        if (!isset($this->map[$country]->$rate)) {
+        $periods = $this->map[$country]['periods'];
+
+        // Sort by date desc
+        usort($periods, function ($period1, $period2) {
+            return new \DateTime($period1['effective_from']) > new \DateTime($period2['effective_from']) ? -1 : 1;
+        });
+
+        foreach ($periods AS $period) {
+            if (new \DateTime($period['effective_from']) > $applicableDate) {
+                continue;
+            }
+            else {
+                break;
+            }
+        }
+
+        if (empty($period)) {
+            throw new Exception('Unable to find a rate applicable at that date.');
+        }
+
+        if (!isset($period['rates'][$rate])) {
             throw new Exception('Invalid rate.');
         }
 
-        return $this->map[$country]->$rate;
+        return $period['rates'][$rate];
     }
 
     /**

--- a/tests/RatesTest.php
+++ b/tests/RatesTest.php
@@ -45,12 +45,40 @@ class RatesTest extends PHPUnit_Framework_TestCase
      * @covers Rates::country
      */
     public function test_country() {
-        $data = array(
-            'NL' => (object) [
-                'standard' => 21,
-                'reduced' => 15
+        $data = [
+            'NL' => [
+                'name'         => 'Netherlands',
+                'code'         => 'NL',
+                'country_code' => 'NL',
+                'periods'      =>
+                    [
+                        [
+                            'effective_from' => '2020-01-01',
+                            'rates'          =>
+                                [
+                                    'reduced'  => 7.0,
+                                    'standard' => 22.0,
+                                ],
+                        ],
+                        [
+                            'effective_from' => '2012-10-01',
+                            'rates'          =>
+                                [
+                                    'reduced'  => 6.0,
+                                    'standard' => 21.0,
+                                ],
+                        ],
+                        [
+                            'effective_from' => '0000-01-01',
+                            'rates'          =>
+                                [
+                                    'reduced'  => 5.0,
+                                    'standard' => 19.0,
+                                ],
+                        ],
+                    ],
             ]
-        );
+        ];
         $mock = $this->getClientMock();
         $mock
             ->method('fetch')
@@ -58,25 +86,61 @@ class RatesTest extends PHPUnit_Framework_TestCase
 
         $rates = new Rates($mock, null);
 
+        // Return correct VAT rates
+        self::assertEquals(  $rates->country('NL'), 21 );
+        self::assertEquals(  $rates->country('NL', 'reduced'), 6 );
+
+        // Return correct VAT rates on an older period
+        self::assertEquals($rates->country('NL', 'standard', new \DateTimeImmutable('2010-01-01')), 19);
+        self::assertEquals($rates->country('NL', 'reduced', new \DateTimeImmutable('2010-01-01')), 5);
+
+        // Return correct VAT rates on an future period
+        self::assertEquals($rates->country('NL', 'standard', new \DateTimeImmutable('2022-01-01')), 22);
+        self::assertEquals($rates->country('NL', 'reduced', new \DateTimeImmutable('2022-01-01')), 7);
+
         // Exception when supplying country code for which we have no rate
         self::expectException( 'Exception' );
         $rates->country('US');
-
-        // Return correct VAT rates
-        self::assertEquals(  $rates->country('NL'), 21 );
-        self::assertEquals(  $rates->country('NL', 'reduced'), 15 );
     }
 
     /**
      * @covers Rates::all()
      */
     public function test_all() {
-        $data = array(
-            'NL' => (object) [
-                'standard' => 21,
-                'reduced' => 15
+        $data = [
+            'NL' => [
+                'name'         => 'Netherlands',
+                'code'         => 'NL',
+                'country_code' => 'NL',
+                'periods'      =>
+                    [
+                        [
+                            'effective_from' => '2020-01-01',
+                            'rates'          =>
+                                [
+                                    'reduced'  => 7.0,
+                                    'standard' => 22.0,
+                                ],
+                        ],
+                        [
+                            'effective_from' => '2012-10-01',
+                            'rates'          =>
+                                [
+                                    'reduced'  => 6.0,
+                                    'standard' => 21.0,
+                                ],
+                        ],
+                        [
+                            'effective_from' => '0000-01-01',
+                            'rates'          =>
+                                [
+                                    'reduced'  => 5.0,
+                                    'standard' => 19.0,
+                                ],
+                        ],
+                    ],
             ]
-        );
+        ];
         $mock = $this->getClientMock();
         $mock
             ->method('fetch')
@@ -91,7 +155,40 @@ class RatesTest extends PHPUnit_Framework_TestCase
      */
     public function test_ratesAreLoadedFromCache() {
         $mock = $this->getCacheMock();
-        $data = array( 'NL' => (object) [ 'standard' => 21, 'reduced' => 15 ]);
+        $data = [
+            'NL' => [
+                'name'         => 'Netherlands',
+                'code'         => 'NL',
+                'country_code' => 'NL',
+                'periods'      =>
+                    [
+                        [
+                            'effective_from' => '2020-01-01',
+                            'rates'          =>
+                                [
+                                    'reduced'  => 7.0,
+                                    'standard' => 22.0,
+                                ],
+                        ],
+                        [
+                            'effective_from' => '2012-10-01',
+                            'rates'          =>
+                                [
+                                    'reduced'  => 6.0,
+                                    'standard' => 21.0,
+                                ],
+                        ],
+                        [
+                            'effective_from' => '0000-01-01',
+                            'rates'          =>
+                                [
+                                    'reduced'  => 5.0,
+                                    'standard' => 19.0,
+                                ],
+                        ],
+                    ],
+            ]
+        ];
 
         $mock
             ->method('get')
@@ -103,8 +200,17 @@ class RatesTest extends PHPUnit_Framework_TestCase
         self::assertNotEmpty($rates->all());
         self::assertEquals($rates->all(), $data);
 
+        // Return correct VAT rates
         self::assertEquals($rates->country('NL'), 21);
-        self::assertEquals($rates->country('NL', 'reduced'), 15);
+        self::assertEquals($rates->country('NL', 'reduced'), 6);
+
+        // Return correct VAT rates on an older period
+        self::assertEquals($rates->country('NL', 'standard', new \DateTimeImmutable('2010-01-01')), 19);
+        self::assertEquals($rates->country('NL', 'reduced', new \DateTimeImmutable('2010-01-01')), 5);
+
+        // Return correct VAT rates on an future period
+        self::assertEquals($rates->country('NL', 'standard', new \DateTimeImmutable('2022-01-01')), 22);
+        self::assertEquals($rates->country('NL', 'reduced', new \DateTimeImmutable('2022-01-01')), 7);
     }
 
     /**


### PR DESCRIPTION
Hi,

For reasons, I had to find which was the VAT rate for a country on a specific date.
jsonvat.com provides this information, but this is currently squeezed by the vat.php library, which only fetches the currently applicable rate.

This PR changes the way rates are fetched (which may introduce a BC break for advanced users, but nothing really new otherwise), so if merged, this may need a bound to a new minor version.

The case of a "future" VAT rate (a future applicable rate already defined) is also handled (cf tests).