### PR TITLE
Instantiate client only when required

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -99,6 +99,8 @@ class Validator {
      * @param string $vatNumber Either the full VAT number (incl. country) or just the part after the country code.
      *
      * @return boolean
+     *
+     * @throws Vies\ViesException
      */
     public function validate( $vatNumber ) {
        return $this->validateFormat( $vatNumber ) && $this->validateExistence( $vatNumber );

--- a/src/Vies/Client.php
+++ b/src/Vies/Client.php
@@ -15,7 +15,12 @@ class Client {
     /**
      * @var SoapClient
      */
-    protected $client;
+    private $client;
+
+    /**
+     * @var int
+     */
+    protected $timeout;
 
     /**
      * Client constructor.
@@ -23,7 +28,7 @@ class Client {
      * @param int $timeout How long should we wait before aborting the request to VIES?
      */
     public function __construct($timeout = 10) {
-        $this->client = new SoapClient( self::URL, [ 'connection_timeout' => $timeout ]);
+        $this->timeout = $timeout;
     }
 
     /**
@@ -36,7 +41,7 @@ class Client {
      */
     public function checkVat( $countryCode, $vatNumber ) {
         try {
-            $response = $this->client->checkVat(
+            $response = $this->getClient()->checkVat(
                 array(
                     'countryCode' => $countryCode,
                     'vatNumber' => $vatNumber
@@ -47,5 +52,17 @@ class Client {
         }
 
         return (bool) $response->valid;
+    }
+
+    /**
+     * @return SoapClient
+     */
+    protected function getClient()
+    {
+        if ($this->client === null) {
+            $this->client = new SoapClient(self::URL, ['connection_timeout' => $this->timeout]);
+        }
+
+        return $this->client;
     }
 }


### PR DESCRIPTION
This improves this repo in two ways:

1. WSDL only requested when validate method actually used.
2. The WSDL client constructor can throw; and this is now properly catched and wrapped in a `ViesException`.