### PR TITLE
Remove deprecated function curl_close

### DIFF
--- a/src/Clients/IbericodeVatRatesClient.php
+++ b/src/Clients/IbericodeVatRatesClient.php
@@ -26,7 +26,6 @@ class IbericodeVatRatesClient implements Client
         ]);
         $body = (string) curl_exec($ch);
         $status = (int) curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
-        curl_close($ch);
 
         if ($body === '' || $status >= 400) {
             throw new ClientException("Error fetching rates from {$url}.");


### PR DESCRIPTION
   DEPRECATED  Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0